### PR TITLE
Fix rank items

### DIFF
--- a/implicit/nearest_neighbours.py
+++ b/implicit/nearest_neighbours.py
@@ -64,7 +64,7 @@ class ItemItemRecommender(RecommenderBase):
             raise IndexError("Some of selected itemids are not in the model")
 
         # calculate the relevance scores
-        liked_vector = user_items[userid]
+        liked_vector = user_items.getrow(userid)
         recommendations = liked_vector.dot(self.similarity)
 
         # remove items that are not in the selected_items


### PR DESCRIPTION
The line `liked_vector = user_items[user_id]` loses information about the indices.

`recommendations.indices` returns a vector where all elements are zero `[0, 0,...,0]`.

This impacts the line `best = sorted(zip(recommendations.indices, recommendations.data), key=lambda x: -x[1])`.

If you run `rank_items(...)`, you will find the returned output looks like follows: `[(0, similarity), (0, similarity), (0, similarity)]`.

Fix here is to simply replace `user_items[user_id]` with `user_items.getrow(user_id)` which returns the same vector but retains information about the indices.

`recommendations.indices` will perform as expected returning a vector where all elements are indices `e.g. [0, 1,...,N]`.